### PR TITLE
Improve SQLI2

### DIFF
--- a/vulnerable_webapp_scorpiontornado/app.py
+++ b/vulnerable_webapp_scorpiontornado/app.py
@@ -133,7 +133,7 @@ def create_app(test_config=None):
         error = None
         hints = [
             "As always, first try and use the system normally. Next, try and break it!",
-            "Try entering a student ID that doesn't exist, nothing, or a single quote ' into the student ID field. What does this tell us about the system?",
+            "Try entering a student ID that doesn't exist, nothing, or a single quote <code>'</code> into the student ID field. What does this tell us about the system?",
             (
                 "We also know that when we enter a single quote, we get an error - so, the system may be vulnerable to SQL injection. "
                 "However, unlike SQLI 1, simply selecting all rows won't suffice. "
@@ -141,26 +141,36 @@ def create_app(test_config=None):
                 "Where else could it be hidden?"
             ),
             (
-                "UNION is a SQL operator that allows you to combine the results of two queries. "
-                "Also, most database management systems have a table that contains information about the database itself, like the names of tables."
+                "Because of the way the server is configured, we can't simply end the query with a semicolon and start a new one. "
+                "To get around this, you might find the <code>UNION</code> SQL operator helpful - it allows you to combine the results of two queries. "
+                "</br></br>Also, most database management systems have a table that contains information about the database itself, like the names of tables."
                 "</br></br>To save you some trial-and-error, this server is using sqlite3, which has a table called <a href='https://www.sqlite.org/schematab.html'>sqlite_master</a>. "
                 "Try researching these concepts and see if you can find some information about table names."
                 "</br></br>(Note: other DBMSs have similar tables, like <code>INFORMATION_SCHEMA.tables</code> and <code>INFORMATION_SCHEMA.columns</code> for MySQL)."
             ),
             (
-                "Relevant columns of sqlite_master include <code>name</code> (the name of the table) and <code>sql</code> (the SQL used to create the table). "
-                "You can also use the value <code>1</code> as if it were a column - it will make a column with only 1's. "
+                "Relevant columns of sqlite_master include <code>name</code> (the name of the table) and <code>sql</code> (the SQL used to create the table)."
+                "</br></br>You can also use the value <code>1</code> in a SELECT statement as if it were a column - it will make a column with only 1's. "
                 "This is handy because <code>UNION</code>s are only valid if the number of columns in both <code>SELECT</code> statements match."
+                "</br></br>(In other DBMSs with strict typing, you might need to match the datatype to make the UNION valid "
+                "- <code>NULL</code> works in most cases, but if the column is specifically <code>NOT NULL</code> you'll have to use e.g. <code>'a'</code> for a text column. "
+                "You don't need that for this challenge though)"
             ),
             (
                 "Try entering <code>1 UNION SELECT name,sql,1 FROM sqlite_master WHERE type='table'</code> into the student ID field. "
                 "This will return the name and SQL used to create each table in the database, including information about columns. "
                 # "The <code>1</code> will create a column with only 1's. This  to make the UNION valid - we need the same number of columns as the original query. "
             ),
-            # TODO add more hints
+            (
+                "Now that you know the tables in the database and their columns, "
+                "try using UNIONs to extract data from the tables to get the two flags. "
+                "<br/><br/>I don't want to give too much away for this challenge, so good luck! "
+                "Don't be afraid to Google things, like SQL UNION syntax!"
+            )
+            # Important concepts:
             #   - Padding with 1- or NULL-filled columns to make the UNION valid / get the same number of columns as the original query
             #   - UNION with sqlite_master to find table names
-            #       UNION SELECT * FROM sqlite_master WHERE type = 'table'
+            #       Want to run something like SELECT * FROM sqlite_master WHERE type = 'table'
             #           (mention INFORMATION_SCHEMA.tables, INFORMATION_SCHEMA.columns for MySQL)
             #       1 UNION SELECT name, tbl_name, sql FROM sqlite_master WHERE type = 'table'
             #   - UNION with sqlite_master to find column names

--- a/vulnerable_webapp_scorpiontornado/sqli2_schema.sql
+++ b/vulnerable_webapp_scorpiontornado/sqli2_schema.sql
@@ -5,7 +5,11 @@
 -- Inspiration drawn from COMP3311 23T3 assignment 2 (https://webcms3.cse.unsw.edu.au/COMP3311/23T3/resources/89176)
 -- and the COMP6841 SQLI pre-recorded video (https://youtu.be/bAhvzXfuhg8)
 
--- Note - unis really do keep all this info (and more) about you: https://www.student.unsw.edu.au/privacy
+-- Notes:
+--  Unis really do keep all this info (and more) about you: https://www.student.unsw.edu.au/privacy
+--      Could've also included personal email, country of origin, program of study, fee payment info,
+--      financial assistance and scholarships, disciplinary info etc. but that's too much for this CTF.
+--  Also, date_of_birth is an ISO8601 string in the form "YYYY-MM-DD"
 DROP TABLE IF EXISTS Students;
 CREATE TABLE Students(
     student_id INTEGER CHECK (student_id BETWEEN 1000000 AND 9999999),
@@ -14,19 +18,22 @@ CREATE TABLE Students(
     email TEXT,
     phone_number TEXT,
     home_address TEXT,
-    date_of_birth TEXT, -- ISO8601 string in the form "YYYY-MM-DD"
-    -- Could've also included personal email, country of origin, program of study, fee payment info,
-    -- financial assistance and scholarships, disciplinary info etc. but that's too much for this CTF.
+    date_of_birth TEXT,
     PRIMARY KEY (student_id)
 );
 
+-- Notes:
+--  For 'term', could use the regex from COMP3311 23T3 assignment 2 - '[12][01239]T[0123]',
+--      but sqlite doesn't distribute a regular expression implementation by default. I can't be bothered getting it working..
+--  Could also define grade as something like  grade TEXT CHECK (grade IN ("HD", "DN", "CR", "PS", "FL")),
+--      but this would stop me putting a flag in the grade column.
 DROP TABLE IF EXISTS Marks;
 CREATE TABLE Marks (
     student_id INTEGER,
     course_code TEXT,
-    term TEXT, -- Could use the regex from COMP3311 23T3 assignment 2 - '[12][01239]T[0123]' - but I can't figure out how to do it in sqlite3
+    term TEXT,
     mark INTEGER CHECK (mark BETWEEN 0 AND 100),
-    grade TEXT, -- CHECK (grade IN ("HD", "DN", "CR", "PS", "FL")), -- Simplified model
+    grade TEXT,
     PRIMARY KEY (student_id, course_code),
     FOREIGN KEY (student_id) REFERENCES Students(student_id)
 );

--- a/vulnerable_webapp_scorpiontornado/static/style.css
+++ b/vulnerable_webapp_scorpiontornado/static/style.css
@@ -186,6 +186,7 @@ input.button {
 table {
   margin: 30px;
   table-layout: fixed;
+  overflow-wrap: break-word; /* https://stackoverflow.com/a/27530416 */
   width: 95%;
   border-collapse: collapse;
   border: 1px solid black;

--- a/vulnerable_webapp_scorpiontornado/templates/sqli2.html
+++ b/vulnerable_webapp_scorpiontornado/templates/sqli2.html
@@ -25,7 +25,7 @@
         <tr>
           <td>{{row[0]}}</td>
           <td>{{row[1]}}</td>
-          <td>{{row[2]}}</td> <!-- TODO: mobile support -->
+          <td>{{row[2]}}</td>
         </tr>
       {% endfor %}
     </table>

--- a/vulnerable_webapp_scorpiontornado/templates/sqli_challenge.html
+++ b/vulnerable_webapp_scorpiontornado/templates/sqli_challenge.html
@@ -38,7 +38,7 @@
           </div>
         </div>
       </div>
-      <div class="col-md-4">
+      <div class="col-md-4 mb-4 mb-sm-5">
         <h2>Hints</h2>
         <div class="accordion" id="{{ chal_name }}_hints">
           {% for hint in hints %}


### PR DESCRIPTION
Minor quality of improvements for the SQLI2 challenge.

Still to do is somehow making the production flag for SQLI2 different to the hardcoded value on the github, using Heroku environment variables. Perhaps I could insert or update a row? I'm trying to avoid exposing the database schema in the python files though as it's a major part of the challenge and the python files are fair game for students to read.

I'm happy with how it is for now though, because the flags are in the .sql files which could easily be omitted if given to students, and is a bit more obscure - it'd just be easier to solve the challenge normally rather than finding them hahah.